### PR TITLE
CANRange Triggers

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -334,13 +334,16 @@ public class RobotContainer {
     .onFalse(new AlgaeStowCommand(shoulder, elbow, elevator, wrist, algaeEndEffector));
 
     // Coral Station Intake No Auto Align
-    controller.leftBumper().and(()->!ReefPositionsUtil.getInstance().getIsAutoAligning())
+    controller.leftBumper()
+      .and(()->!ReefPositionsUtil.getInstance().getIsAutoAligning())
+      .and(coralEndEffector.hasCoralTrigger().negate())
       .onTrue(new StationIntakeCommand(shoulder, elbow, elevator, wrist, coralEndEffector))
       .onFalse(new StationIntakeToStow(shoulder, elbow, elevator, wrist, coralEndEffector, algaeEndEffector));
 
     // Coral Station Intake Auto Align Sequence
     controller.leftBumper()
       .and(() -> ReefPositionsUtil.getInstance().getIsAutoAligning())
+      .and(coralEndEffector.hasCoralTrigger().negate())
       .onTrue(StationIntakeCommandFactory.getNewStationIntakeSequence(
           () -> intakePosChooser.get(),
           true,

--- a/src/main/java/frc/robot/subsystems/algaeendeffector/AlgaeEndEffector.java
+++ b/src/main/java/frc/robot/subsystems/algaeendeffector/AlgaeEndEffector.java
@@ -15,72 +15,55 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.robot.subsystems.algaeendeffector.ToesiesInputsAutoLogged;
 import frc.robot.util.LoggedTunableGainsBuilder;
 import frc.robot.util.LoggedTunableNumber;
 
 /**
  * <h1>Algae End Effector</h1>
- * <h3>(toesies)</h3>
  * <p>Controls the rollers on the end of our algae end effector</p>
  * <ul>
  * <li>Voltage control</li>
  * </ul>
  */
 public class AlgaeEndEffector extends SubsystemBase {
+  public static LoggedTunableNumber ALGAE_DISTANCE_THRESHOLD = new LoggedTunableNumber("Algae End Effector/AlgaeSensorDistanceInches", 0.1);
   private AlgaeEndEffectorIO m_IO;
 
-  ToesiesInputsAutoLogged logged = new ToesiesInputsAutoLogged();
+  AlgaeEndEffectorInputsAutoLogged logged = new AlgaeEndEffectorInputsAutoLogged();
 
-
-  public AlgaeEndEffector(AlgaeEndEffectorIO toesiesIO) {
-    m_IO = toesiesIO;
+  public AlgaeEndEffector(AlgaeEndEffectorIO io) {
+    m_IO = io;
     logged.angularVelocity = DegreesPerSecond.mutable(0);
     logged.supplyCurrent = Amps.mutable(0);
     logged.torqueCurrent = Amps.mutable(0);
     logged.voltage = Volts.mutable(0);
     logged.voltageSetPoint = Volts.mutable(0);
-    logged.sensorDistance = Meters.mutable(0);
+    logged.hasAlgae = false;
   }
 
-  /**
-   * PLACEHOLDER
-   * gets if the end effector is currently holding a coral
-   * Please replace with an actual method, and change all usages to reflect
-   * TODO: Replace
-   * @return
-   */
-  public BooleanSupplier placeholderGetHasAlgaeSupplier() {
-    return () -> false;
-  }
-
-  public Command getNewSetVoltsCommand(DoubleSupplier volts) {
-    return new InstantCommand(
-        () -> {
-          setTarget(Volts.of((volts.getAsDouble())));
-        },
-        this);
-  }
-
-  public void setTarget(Voltage target) {
+  private void setTarget(Voltage target) {
     m_IO.setTarget(target);
   }
 
-  public Distance getDistance() {
-    return m_IO.getDistance();
+  public Command getNewSetVoltsCommand(DoubleSupplier volts) {
+    return new InstantCommand(() -> {
+      setTarget(Volts.of((volts.getAsDouble())));
+    }, this);
   }
 
   public Command getNewSetVoltsCommand(double i) {
-    return new InstantCommand(
-        () -> {
-          setTarget(Volts.of(i));
-        },
-        this);
+    return new InstantCommand(() -> {
+      setTarget(Volts.of(i));
+    }, this);
+  }
+
+  public Trigger hasAlgaeTrigger() {
+    return new Trigger(() -> logged.hasAlgae);
   }
 
   @Override
   public void periodic() {
     m_IO.updateInputs(logged);
-    Logger.processInputs("RobotState/Toesies", logged);
+    Logger.processInputs("RobotState/Algae End Effector", logged);
   }
 }

--- a/src/main/java/frc/robot/subsystems/algaeendeffector/AlgaeEndEffectorIO.java
+++ b/src/main/java/frc/robot/subsystems/algaeendeffector/AlgaeEndEffectorIO.java
@@ -1,25 +1,21 @@
 package frc.robot.subsystems.algaeendeffector;
 
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.MutAngularVelocity;
 import edu.wpi.first.units.measure.MutCurrent;
-import edu.wpi.first.units.measure.MutDistance;
 import edu.wpi.first.units.measure.MutVoltage;
 import edu.wpi.first.units.measure.Voltage;
-import frc.robot.util.Gains;
-
 import org.littletonrobotics.junction.AutoLog;
 
 public interface AlgaeEndEffectorIO {
 
   @AutoLog
-  public static class ToesiesInputs {
+  public static class AlgaeEndEffectorInputs {
     public MutAngularVelocity angularVelocity;
     public MutVoltage voltage;
     public MutVoltage voltageSetPoint;
     public MutCurrent supplyCurrent;
     public MutCurrent torqueCurrent;
-    public MutDistance sensorDistance;
+    public boolean hasAlgae;
   }
 
   public void setTarget(Voltage target);
@@ -30,9 +26,7 @@ public interface AlgaeEndEffectorIO {
    *
    * <p>
    */
-  public void updateInputs(ToesiesInputs input);
+  public void updateInputs(AlgaeEndEffectorInputs input);
 
   public void stop();
-  
-  public Distance getDistance();
 }

--- a/src/main/java/frc/robot/subsystems/algaeendeffector/AlgaeEndEffectorIONova.java
+++ b/src/main/java/frc/robot/subsystems/algaeendeffector/AlgaeEndEffectorIONova.java
@@ -4,6 +4,7 @@ import com.thethriftybot.ThriftyNova;
 import com.thethriftybot.ThriftyNova.MotorType;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -11,46 +12,41 @@ import com.ctre.phoenix6.hardware.CANrange;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Voltage;
 import frc.robot.subsystems.arm.ArmJointIO.ArmInputs;
+import frc.robot.subsystems.coralendeffector.CoralEndEffector;
 import frc.robot.util.CanDef;
 
 
 
 public class AlgaeEndEffectorIONova implements AlgaeEndEffectorIO {
-  public ThriftyNova Motor;
-  public ArmInputs inputs;
-
+  private ThriftyNova motor;
   private CANrange m_sensor;
 
-  private Voltage m_setPoint = Voltage.ofBaseUnits(0, Volts);
+  private Voltage m_setPoint = Volts.of(0);
 
   public AlgaeEndEffectorIONova(CanDef motorCanDef, CanDef sensorCanDef) {
-    Motor = new ThriftyNova(motorCanDef.id()).setMotorType(MotorType.MINION);
+    motor = new ThriftyNova(motorCanDef.id()).setMotorType(MotorType.MINION);
     m_sensor = new CANrange(sensorCanDef.id(),sensorCanDef.bus());
   }
 
   @Override
-  public void updateInputs(ToesiesInputs inputs) {
-    inputs.angularVelocity.mut_replace(Motor.getVelocity(), RadiansPerSecond);
+  public void updateInputs(AlgaeEndEffectorInputs inputs) {
+    inputs.angularVelocity.mut_replace(motor.getVelocity(), RadiansPerSecond);
     inputs.voltageSetPoint.mut_replace(m_setPoint);
-    inputs.voltage.mut_replace(Motor.getVoltage(), Volts);
-    inputs.supplyCurrent.mut_replace(Motor.getSupplyCurrent(), Amps);
+    inputs.voltage.mut_replace(motor.getVoltage(), Volts);
+    inputs.supplyCurrent.mut_replace(motor.getSupplyCurrent(), Amps);
+    inputs.torqueCurrent.mut_replace(motor.getStatorCurrent(), Amps);
+    inputs.hasAlgae = m_sensor.getDistance().getValue().lt(Inches.of(AlgaeEndEffector.ALGAE_DISTANCE_THRESHOLD.get()));
   }
 
   @Override
   public void setTarget(Voltage target) {
-    Motor.setVoltage(target);;
+    motor.setVoltage(target);;
     m_setPoint = target;
   }
 
   @Override
   public void stop() {
-    Motor.setVoltage(0.0);
-  }
-
-  @Override
-  public Distance getDistance() {
-    return m_sensor.getDistance().getValue();
-
+    motor.setVoltage(0.0);
   }
   
 }

--- a/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffector.java
+++ b/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffector.java
@@ -3,79 +3,64 @@ package frc.robot.subsystems.coralendeffector;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.DegreesPerSecond;
-import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Volts;
 
 import java.util.function.BooleanSupplier;
 
 import org.littletonrobotics.junction.Logger;
 
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.util.LoggedTunableNumber;
 
 /**
  * <h1>Coral end effector</h1>
- * <h3>(fingeys)</h3>
  * <p>Controls the rollers on the end of our coral end effector</p>
  * <ul>
  * <li>Voltage control</li>
  * </ul>
  */
 public class CoralEndEffector extends SubsystemBase {
+  public static LoggedTunableNumber CORAL_DISTANCE_THRESHOLD = new LoggedTunableNumber("Coral End Effector/CoralSensorDistanceInches", 0.1);
+
   private CoralEndEffectorIO m_IO;
+  private CoralEndEffectorInputsAutoLogged logged = new CoralEndEffectorInputsAutoLogged();
 
-  FingeysInputsAutoLogged logged = new FingeysInputsAutoLogged();
-
-  public CoralEndEffector(CoralEndEffectorIO fingeysIO) {
-    m_IO = fingeysIO;
+  public CoralEndEffector(CoralEndEffectorIO io) {
+    m_IO = io;
     logged.angularVelocity = DegreesPerSecond.mutable(0);
     logged.supplyCurrent = Amps.mutable(0);
     logged.torqueCurrent = Amps.mutable(0);
     logged.voltageSetPoint = Volts.mutable(0);
     logged.voltage = Volts.mutable(0);
-    logged.sensorDistance = Meters.mutable(0);
+    logged.hasCoral = false;
   }
 
-  /**
-   * PLACEHOLDER
-   * gets if the end effector is currently holding a coral
-   * Please replace with an actual method, and change all usages to reflect
-   * TODO: Replace
-   * @return
-   */
-  public BooleanSupplier placeholderGetHasCoralSupplier() {
-    return () -> true;
-  }
-
-  public void setTarget(Voltage target) {
+  private void setTarget(Voltage target) {
     m_IO.setTarget(target);
-  }
-  public Distance getDistance() {
-    return m_IO.getDistance();
   }
 
   public Command getNewSetVoltsCommand(LoggedTunableNumber volts) {
-    return new InstantCommand(
-        () -> {
-          setTarget(Volts.of((volts.get())));
-        },
-        this);
+    return new InstantCommand(() -> {
+      setTarget(Volts.of((volts.get())));
+    }, this);
   }
   public Command getNewSetVoltsCommand(double i) {
-    return new InstantCommand(
-        () -> {
-          setTarget(Volts.of(i));
-        },
-        this);
+    return new InstantCommand(() -> {
+      setTarget(Volts.of(i));
+    }, this);
+  }
+
+  public Trigger hasCoralTrigger() {
+    return new Trigger(() -> logged.hasCoral);
   }
 
   @Override
   public void periodic() {
     m_IO.updateInputs(logged);
-    Logger.processInputs("RobotState/Fingeys", logged);
+    Logger.processInputs("RobotState/Coral End Effector", logged);
   }
 }

--- a/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIO.java
+++ b/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIO.java
@@ -6,20 +6,19 @@ import edu.wpi.first.units.measure.MutCurrent;
 import edu.wpi.first.units.measure.MutDistance;
 import edu.wpi.first.units.measure.MutVoltage;
 import edu.wpi.first.units.measure.Voltage;
-import frc.robot.util.Gains;
 
 import org.littletonrobotics.junction.AutoLog;
 
 public interface CoralEndEffectorIO {
 
   @AutoLog
-  public static class FingeysInputs {
+  public static class CoralEndEffectorInputs {
     public MutAngularVelocity angularVelocity;
     public MutVoltage voltage;
     public MutVoltage voltageSetPoint;
     public MutCurrent supplyCurrent;
     public MutCurrent torqueCurrent;
-    public MutDistance sensorDistance;
+    public boolean hasCoral;
   }
 
   public void setTarget(Voltage target);
@@ -30,9 +29,7 @@ public interface CoralEndEffectorIO {
    *
    * <p>
    */
-  public void updateInputs(FingeysInputs input);
+  public void updateInputs(CoralEndEffectorInputs input);
 
   public void stop();
-
-  public Distance getDistance();
 }

--- a/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIONova.java
+++ b/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIONova.java
@@ -4,52 +4,43 @@ import com.thethriftybot.ThriftyNova;
 import com.thethriftybot.ThriftyNova.MotorType;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.hardware.CANrange;
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Voltage;
-import frc.robot.subsystems.arm.ArmJointIO.ArmInputs;
 import frc.robot.util.CanDef;
 
 
 
 public class CoralEndEffectorIONova implements CoralEndEffectorIO {
-  public ThriftyNova Motor;
-  public ArmInputs inputs;
-
+  private ThriftyNova motor;
   private CANrange m_sensor;
-
-  private Voltage m_setPoint = Voltage.ofBaseUnits(0, Volts);
+  private Voltage m_setPoint = Volts.of(0);
 
   public CoralEndEffectorIONova(CanDef motorCanDef, CanDef sensorCanDef) {
-    Motor = new ThriftyNova(motorCanDef.id()).setMotorType(MotorType.MINION);
+    motor = new ThriftyNova(motorCanDef.id()).setMotorType(MotorType.MINION);
     m_sensor = new CANrange(sensorCanDef.id(),sensorCanDef.bus());
   }
 
   @Override
-  public void updateInputs(FingeysInputs inputs) {
-    inputs.angularVelocity.mut_replace(Motor.getVelocity(), RadiansPerSecond);
+  public void updateInputs(CoralEndEffectorInputs inputs) {
+    inputs.angularVelocity.mut_replace(motor.getVelocity(), RadiansPerSecond);
     inputs.voltageSetPoint.mut_replace(m_setPoint);
-    inputs.voltage.mut_replace(Motor.getVoltage(), Volts);
-    inputs.supplyCurrent.mut_replace(Motor.getSupplyCurrent(), Amps);
+    inputs.voltage.mut_replace(motor.getVoltage(), Volts);
+    inputs.supplyCurrent.mut_replace(motor.getSupplyCurrent(), Amps);
+    inputs.hasCoral = m_sensor.getDistance().getValue().lt(Inches.of(CoralEndEffector.CORAL_DISTANCE_THRESHOLD.get()));
   }
 
   @Override
   public void setTarget(Voltage target) {
-    Motor.setVoltage(target);;
+    motor.setVoltage(target);;
     m_setPoint = target;
   }
 
   @Override
   public void stop() {
-    Motor.setVoltage(0.0);
-  }
-
-  @Override
-  public Distance getDistance() {
-    return m_sensor.getDistance().getValue();
-
+    motor.setVoltage(0.0);
   }
 }

--- a/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIOSim.java
+++ b/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIOSim.java
@@ -1,24 +1,22 @@
 package frc.robot.subsystems.coralendeffector;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.DegreesPerSecond;
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.MutDistance;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.simulation.FlywheelSim;
+import frc.robot.util.LoggedTunableNumber;
 
 public class CoralEndEffectorIOSim implements CoralEndEffectorIO {
-
   private Voltage appliedVoltage = Volts.mutable(0.0);
+  private LoggedTunableNumber coralEESensorSim = new LoggedTunableNumber("Coral End Effector/SensorDistanceInches", 1);
 
   private final FlywheelSim sim;
-  private MutDistance intakeSensorDistance;
 
   public CoralEndEffectorIOSim(int motorId) {
     sim = new FlywheelSim(
@@ -28,7 +26,6 @@ public class CoralEndEffectorIOSim implements CoralEndEffectorIO {
         1
         ), 
       DCMotor.getKrakenX60Foc(1), 0.01);
-    intakeSensorDistance = Meters.mutable(1);
   }
 
   @Override
@@ -41,14 +38,12 @@ public class CoralEndEffectorIOSim implements CoralEndEffectorIO {
   }
 
   @Override
-  public void updateInputs(FingeysInputs input) {
-    input.angularVelocity.mut_replace(
-        DegreesPerSecond.convertFrom(sim.getAngularVelocityRadPerSec(), RadiansPerSecond),
-        DegreesPerSecond);
+  public void updateInputs(CoralEndEffectorInputs input) {
+    input.angularVelocity.mut_replace(sim.getAngularVelocity());
     input.supplyCurrent.mut_replace(sim.getCurrentDrawAmps(), Amps);
     input.torqueCurrent.mut_replace(input.supplyCurrent.in(Amps), Amps);
     input.voltageSetPoint.mut_replace(appliedVoltage);
-    input.sensorDistance.mut_replace(intakeSensorDistance);
+    input.hasCoral = Inches.of(coralEESensorSim.get()).lt(Inches.of(CoralEndEffector.CORAL_DISTANCE_THRESHOLD.get()));
 
     // Periodic
     sim.setInputVoltage(appliedVoltage.in(Volts));
@@ -58,11 +53,6 @@ public class CoralEndEffectorIOSim implements CoralEndEffectorIO {
   @Override
   public void stop() {
     setTarget(Volts.of(0.0));
-  }
-
-  @Override
-  public Distance getDistance() {
-      return intakeSensorDistance.copy();
   }
   
 }

--- a/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/coralendeffector/CoralEndEffectorIOTalonFX.java
@@ -8,24 +8,23 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Volts;
 
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Voltage;
 import frc.robot.util.CanDef;
 import frc.robot.util.PhoenixUtil;
 
 public class CoralEndEffectorIOTalonFX implements CoralEndEffectorIO {
-  public VoltageOut Request;
-  public TalonFX Motor;
-
-  private Voltage m_setPoint = Voltage.ofBaseUnits(0, Volts);
-
+  private VoltageOut request;
+  private TalonFX motor;
   private CANrange m_sensor;
 
+  private Voltage m_setPoint = Volts.of(0);
+
   public CoralEndEffectorIOTalonFX(CanDef canbus, CanDef sensorCanDef) {
-    Motor = new TalonFX(canbus.id(),canbus.bus());
-    Request = new VoltageOut(0.0);
+    motor = new TalonFX(canbus.id(),canbus.bus());
+    request = new VoltageOut(0.0);
     m_sensor = new CANrange(sensorCanDef.id(),sensorCanDef.bus());
     
     configureTalons();
@@ -41,32 +40,28 @@ public class CoralEndEffectorIOTalonFX implements CoralEndEffectorIO {
     cfg.Voltage.PeakForwardVoltage = 16.0;
     cfg.Voltage.PeakReverseVoltage = 16.0;
     cfg.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
-    PhoenixUtil.tryUntilOk(5, () -> Motor.getConfigurator().apply(cfg));
+    PhoenixUtil.tryUntilOk(5, () -> motor.getConfigurator().apply(cfg));
   }
 
   @Override
-  public void updateInputs(FingeysInputs inputs) {
-    inputs.angularVelocity.mut_replace(Motor.getVelocity().getValue());
+  public void updateInputs(CoralEndEffectorInputs inputs) {
+    inputs.angularVelocity.mut_replace(motor.getVelocity().getValue());
     inputs.voltageSetPoint.mut_replace(m_setPoint);
-    inputs.voltage.mut_replace(Motor.getMotorVoltage().getValue());
-    inputs.supplyCurrent.mut_replace(Motor.getSupplyCurrent().getValue());
-    inputs.sensorDistance.mut_replace(m_sensor.getDistance(true).getValue());
+    inputs.voltage.mut_replace(motor.getMotorVoltage().getValue());
+    inputs.supplyCurrent.mut_replace(motor.getSupplyCurrent().getValue());
+    inputs.torqueCurrent.mut_replace(motor.getStatorCurrent().getValue());
+    inputs.hasCoral = m_sensor.getDistance().getValue().lt(Inches.of(CoralEndEffector.CORAL_DISTANCE_THRESHOLD.get()));
   }
 
   @Override
   public void setTarget(Voltage target) {
-    Request = Request.withOutput(target);
-    Motor.setControl(Request);
+    request = request.withOutput(target);
+    motor.setControl(request);
     m_setPoint = target;
   }
 
   @Override
   public void stop() {
-    Motor.setControl(new StaticBrake());
-  }
-
-  @Override
-  public Distance getDistance() {
-    return m_sensor.getDistance().getValue();
+    motor.setControl(new StaticBrake());
   }
 }

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -4,14 +4,8 @@ import org.littletonrobotics.junction.Logger;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.DegreesPerSecond;
-import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Volts;
 
-import java.util.function.Supplier;
-
-import javax.sound.sampled.ReverbType;
-
-import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -20,9 +14,10 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.util.LoggedTunableNumber;
 
 public class Intake extends SubsystemBase{
-  private IntakeIO m_intakeIO;
+  public static LoggedTunableNumber CORAL_DISTANCE_THRESHOLD = new LoggedTunableNumber("Intake/CoralSensorDistanceInches", 0.1);
 
-  IntakeInputsAutoLogged loggedIntake = new IntakeInputsAutoLogged();
+  private IntakeIO m_intakeIO;
+  private IntakeInputsAutoLogged loggedIntake = new IntakeInputsAutoLogged();
 
   public Intake(IntakeIO intakeIO) {
     m_intakeIO = intakeIO;
@@ -33,40 +28,31 @@ public class Intake extends SubsystemBase{
     loggedIntake.voltageSetPoint = Volts.mutable(0);
   }
 
-  public void setTarget(Voltage target) {
+  private void setTarget(Voltage target) {
     m_intakeIO.setTarget(target);
   }
 
   public Command getNewSetVoltsCommand(LoggedTunableNumber volts) {
-    return new InstantCommand(
-        () -> {
-          setTarget(Volts.of((volts.get())));
-        },
-        this);
+    return new InstantCommand(() -> {
+      setTarget(Volts.of((volts.get())));
+    }, this);
   }
 
   public Command getNewSetVoltsCommand(double i) {
-    return new InstantCommand(
-        () -> {
-          setTarget(Volts.of(i));
-        },
-        this);
+    return new InstantCommand(() -> {
+      setTarget(Volts.of(i));
+    }, this);
   }
 
   public Command getNewSetSpeedCommand(double percentOutput) {
-    return new InstantCommand(
-      () -> {
-        double volts = 12.0 * percentOutput;
-        setTarget(Volts.of(volts));
-      },
-      this
-    );
+    return new InstantCommand(() -> {
+      double volts = 12.0 * percentOutput;
+      setTarget(Volts.of(volts));
+    }, this);
   }
 
-  public Trigger getNewHasCoralTrigger() {
-    return new Trigger(() -> {
-      return true;
-    });
+  public Trigger hasCoralTrigger() {
+    return new Trigger(() -> loggedIntake.hasCoral);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -1,17 +1,13 @@
 package frc.robot.subsystems.intake;
 
 
-import java.util.function.Supplier;
-
 import org.littletonrobotics.junction.AutoLog;
 
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.MutAngularVelocity;
 import edu.wpi.first.units.measure.MutCurrent;
-import edu.wpi.first.units.measure.MutDistance;
 import edu.wpi.first.units.measure.MutVoltage;
 import edu.wpi.first.units.measure.Voltage;
-import frc.robot.util.Gains;
 
 public interface IntakeIO {
 
@@ -22,7 +18,7 @@ public interface IntakeIO {
     public MutVoltage voltage;
     public MutCurrent supplyCurrent;
     public MutCurrent statorCurrent;
-    public MutDistance sensorDistance;
+    public boolean hasCoral;
   }
 
   public void setTarget(Voltage setpoint);
@@ -30,6 +26,4 @@ public interface IntakeIO {
   public void updateInputs(IntakeInputs input);
 
   public void stop();
-
-  public Distance getSensor();
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIONova.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIONova.java
@@ -14,6 +14,7 @@ import com.thethriftybot.ThriftyNova.CurrentType;
 import com.thethriftybot.ThriftyNova.MotorType;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Distance;
@@ -49,6 +50,7 @@ public class IntakeIONova implements IntakeIO {
     inputs.voltageSetPoint.mut_replace(m_setPoint);
     inputs.voltage.mut_replace(Volts.of(Motor.getVoltage()));
     inputs.supplyCurrent.mut_replace(Amps.of(Motor.getSupplyCurrent()));
+    inputs.hasCoral = rangeSensor.getDistance().getValue().lt(Inches.of(Intake.CORAL_DISTANCE_THRESHOLD.get()));
   }
 
   @Override
@@ -60,11 +62,5 @@ public class IntakeIONova implements IntakeIO {
   @Override
   public void stop() {
     Motor.setVoltage(0);
-  }
-
-  //TODO: IMPLEMENT RANGE SENSOR
-  @Override
-  public Distance getSensor() {
-      return rangeSensor.getDistance(true).getValue();
   }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
@@ -26,13 +26,10 @@ public class IntakeIOSim implements IntakeIO {
 
   private final LinearSystem<N2, N1, N2> m_flywheelPlant = LinearSystemId.createDCMotorSystem(flwheel_kV, flwheel_kA);
 
-  private LoggedTunableNumber intakeSensorSim;
-  private MutDistance intakeSensorDistance;
+  private LoggedTunableNumber intakeSensorSim = new LoggedTunableNumber("Sim/Intake/SensorDistanceInches", 1);
 
   public IntakeIOSim(int motorId) {
     sim = new DCMotorSim(m_flywheelPlant, DRIVE_GEARBOX, 0.1, 0.1);
-    intakeSensorDistance = Meters.mutable(1);
-    intakeSensorSim = new LoggedTunableNumber("RobotState/Intake/SensorInput", 1);
   }
 
   @Override
@@ -42,17 +39,13 @@ public class IntakeIOSim implements IntakeIO {
 
   @Override
   public void updateInputs(IntakeInputs input) {
-    //Inputs
-    intakeSensorDistance.mut_replace(Meters.of(intakeSensorSim.get()));
-
     //Logging
-    input.angularVelocity.mut_replace(
-        DegreesPerSecond.convertFrom(sim.getAngularVelocityRadPerSec(), RadiansPerSecond),
-        DegreesPerSecond);
+    input.angularVelocity.mut_replace(sim.getAngularVelocity());
     input.supplyCurrent.mut_replace(sim.getCurrentDrawAmps(), Amps);
     input.statorCurrent.mut_replace(sim.getCurrentDrawAmps(), Amps);
     input.voltageSetPoint.mut_replace(appliedVoltage);
     input.voltage.mut_replace(Volts.of(sim.getInputVoltage()));
+    input.hasCoral = Inches.of(intakeSensorSim.get()).lt(Inches.of(Intake.CORAL_DISTANCE_THRESHOLD.get()));
 
     // Periodic
     sim.setInputVoltage(appliedVoltage.in(Volts));
@@ -61,10 +54,5 @@ public class IntakeIOSim implements IntakeIO {
 
   @Override
   public void stop() {
-  }
-
-  @Override
-  public Distance getSensor() {
-      return Feet.of(0);
   }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOTalonFX.java
@@ -1,7 +1,5 @@
 package frc.robot.subsystems.intake;
 
-import java.util.function.Supplier;
-
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.StaticBrake;
 import com.ctre.phoenix6.controls.VoltageOut;
@@ -10,22 +8,22 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Volts;
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Voltage;
 import frc.robot.util.CanDef;
 import frc.robot.util.PhoenixUtil;
 
 public class IntakeIOTalonFX implements IntakeIO {
-  public VoltageOut Request;
-  public TalonFX Motor;
-
+  private VoltageOut request;
+  private TalonFX motor;
   private CANrange rangeSensor;
-  private Voltage m_setPoint = Voltage.ofBaseUnits(0, Volts);
+  
+  private Voltage m_setPoint = Volts.of(0);
 
   public IntakeIOTalonFX(CanDef motorCanDef) {
-    Motor = new TalonFX(motorCanDef.id(),motorCanDef.bus());
-    Request = new VoltageOut(0.0);
+    motor = new TalonFX(motorCanDef.id(),motorCanDef.bus());
+    request = new VoltageOut(m_setPoint);
 
     configureTalons();
   }
@@ -38,32 +36,28 @@ public class IntakeIOTalonFX implements IntakeIO {
     cfg.CurrentLimits.SupplyCurrentLimit = 40;
     cfg.CurrentLimits.SupplyCurrentLimitEnable = true;
     cfg.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
-    PhoenixUtil.tryUntilOk(5, () -> Motor.getConfigurator().apply(cfg));
+    PhoenixUtil.tryUntilOk(5, () -> motor.getConfigurator().apply(cfg));
   }
 
   @Override
   public void updateInputs(IntakeInputs inputs) {
-    inputs.angularVelocity.mut_replace(Motor.getVelocity().getValue());
+    inputs.angularVelocity.mut_replace(motor.getVelocity().getValue());
     inputs.voltageSetPoint.mut_replace(m_setPoint);
-    inputs.voltage.mut_replace(Motor.getMotorVoltage().getValue());
-    inputs.supplyCurrent.mut_replace(Motor.getSupplyCurrent().getValue());
+    inputs.voltage.mut_replace(motor.getMotorVoltage().getValue());
+    inputs.supplyCurrent.mut_replace(motor.getSupplyCurrent().getValue());
+    inputs.statorCurrent.mut_replace(motor.getStatorCurrent().getValue());
+    inputs.hasCoral = rangeSensor.getDistance().getValue().lt(Inches.of(Intake.CORAL_DISTANCE_THRESHOLD.get()));
   }
 
   @Override
   public void setTarget(Voltage target) {
-    Request = Request.withOutput(target);
-    Motor.setControl(Request);
+    request = request.withOutput(target);
+    motor.setControl(request);
     m_setPoint = target;
   }
 
   @Override
   public void stop() {
-    Motor.setControl(new StaticBrake());
-  }
-
-  //TODO: IMPLEMENT RANGE SENSOR
-  @Override
-  public Distance getSensor() {
-      return rangeSensor.getDistance(true).getValue();
+    motor.setControl(new StaticBrake());
   }
 }

--- a/src/main/java/frc/robot/subsystems/intakeextender/IntakeExtender.java
+++ b/src/main/java/frc/robot/subsystems/intakeextender/IntakeExtender.java
@@ -50,28 +50,24 @@ public class IntakeExtender extends SubsystemBase {
     return ()->loggedintakeExtender.Angle;
   }
 
-  public void setAngle(Angle angle) {
+  private void setAngle(Angle angle) {
     m_intakeextenderIO.setTarget(angle);
   }
   
   public Command getNewIntakeExtenderTurnCommand(LoggedTunableNumber angle) {
-    return new InstantCommand(
-      () -> {
-        setAngle(Degrees.of((MathUtil.clamp(angle.get(), groundIntakeMinDeg, groundIntakeMaxDeg))));
-      },
-      this); 
+    return new InstantCommand(() -> {
+      setAngle(Degrees.of((MathUtil.clamp(angle.get(), groundIntakeMinDeg, groundIntakeMaxDeg))));
+    }, this); 
   }
 
   public Command getNewIntakeExtenderTurnCommand(double i) {
-    return new InstantCommand(
-      () -> {
-        setAngle(Degrees.of(i));
-      },
-      this);
+    return new InstantCommand(() -> {
+      setAngle(Degrees.of(i));
+    }, this);
   }
 
   public Trigger getNewAtAngleTrigger(Angle angle,Angle tolerance) {
-     return new Trigger(() -> {
+    return new Trigger(() -> {
       return MathUtil.isNear(angle.baseUnitMagnitude(), loggedintakeExtender.Angle.baseUnitMagnitude(), tolerance.baseUnitMagnitude());
     });
   }


### PR DESCRIPTION
Refactored the CANRange's for the Intake, Coral EE, and Algae EE. Instead of a separate `getDistance` method, this just uses the value inside of the IOInputs for each subsystem. Also moved the detection logic into the implementations of the IO instead of at the subsystem level. For simulation, you can set the range of each sensor with a tunable number at "TunableNumbers/<subsystem>/SensorDistanceInches". 

I implemented the trigger for the coral end effector such that when intaking, once the ee detects coral, it stops the command. You can verify this in simulation by holding down the intake button, and then changing the SensorDistanceInches to less than 0.1. Once you do that, while still holding the button, the command will cancel. 